### PR TITLE
Update graphics.js

### DIFF
--- a/src/engine/renderer/graphics.js
+++ b/src/engine/renderer/graphics.js
@@ -252,7 +252,7 @@ game.createClass('GraphicsData', {
         }
 
         if (this.fillColor && this.fillAlpha) context.fill();
-        if (this.lineWidth) context.stroke();
+        if (this.lineWidth) context.globalAlpha = this.lineAlpha * alpha; context.stroke();
     }
 });
 


### PR DESCRIPTION
Panda used to have an option to set a shape's stroke opacity using the lineStyle method and I noticed the new version is missing it. I don't know if removing it was your intention but this change solved it for me.